### PR TITLE
Cache stylesheet indices for portable fallback extraction

### DIFF
--- a/src/portableFallback/extractor.test.ts
+++ b/src/portableFallback/extractor.test.ts
@@ -1,5 +1,16 @@
-import { describe, expect, it } from 'vitest'
-import { buildPortableFallbackComponentJs, buildPortableFallbackExtractionDiagnostics, type PortableFallbackExtractionStats } from './extractor'
+import { beforeAll, describe, expect, it } from 'vitest'
+import {
+  PSEUDO_STATES,
+  buildPortableFallbackComponentJs,
+  buildPortableFallbackExtractionDiagnostics,
+  buildSheetIndices,
+  pickPseudoDeclarations,
+} from './extractor'
+import type {
+  PortableFallbackExtractionStats,
+  PseudoRuleIndexEntry,
+  PseudoState,
+} from './extractor'
 
 const baseStats = (): PortableFallbackExtractionStats => ({
   nodeCount: 12,
@@ -52,5 +63,346 @@ describe('buildPortableFallbackExtractionDiagnostics', () => {
     expect(diagnostics.warnings).toContain('portable-fallback-large-subtree:260')
     expect(diagnostics.confidencePenalty).toBeGreaterThan(0.5)
     expect(diagnostics.confidence).toBeLessThan(0.5)
+  })
+})
+
+beforeAll(() => {
+  const g = globalThis as Record<string, unknown>
+  if (typeof g.CSSKeyframesRule === 'undefined') {
+    const probe = document.createElement('style')
+    probe.textContent = '@keyframes __csnap_probe { from {} to {} }'
+    document.head.appendChild(probe)
+    const probeSheet = probe.sheet
+    const ctor = probeSheet?.cssRules[0]?.constructor
+    if (ctor) Object.defineProperty(g, 'CSSKeyframesRule', { value: ctor, configurable: true })
+    probe.remove()
+  }
+})
+
+const cssToSheet = (css: string): CSSStyleSheet => {
+  const el = document.createElement('style')
+  el.textContent = css
+  document.head.appendChild(el)
+  const sheet = el.sheet
+  if (!sheet) throw new Error('failed to construct stylesheet from css')
+  return sheet
+}
+
+const trackSheet = (sheet: CSSStyleSheet) => {
+  const counter = { rules: 0 }
+  const proxy = new Proxy(sheet, {
+    get(target, prop, _receiver) {
+      if (prop === 'cssRules') counter.rules += 1
+      return Reflect.get(target, prop, target)
+    },
+  })
+  return { proxy, counter }
+}
+
+const legacyNormalize = (selectorText: string) =>
+  selectorText
+    .replace(/:hover/g, '')
+    .replace(/:focus-visible/g, '')
+    .replace(/:focus-within/g, '')
+    .replace(/:focus/g, '')
+    .replace(/:active/g, '')
+    .trim()
+
+const legacyCollectPseudoDeclarations = (
+  el: Element,
+  pseudo: PseudoState,
+  sheets: readonly CSSStyleSheet[],
+): Map<string, string> => {
+  const declarations = new Map<string, string>()
+  for (const sheet of sheets) {
+    try {
+      for (const rule of Array.from(sheet.cssRules)) {
+        if (!(rule instanceof CSSStyleRule) || !rule.selectorText.includes(pseudo)) continue
+        for (const sel of rule.selectorText.split(',').map((s) => s.trim())) {
+          if (!sel.includes(pseudo)) continue
+          const norm = legacyNormalize(sel)
+          if (!norm) continue
+          try {
+            if (el.matches(norm)) {
+              for (let i = 0; i < rule.style.length; i += 1) {
+                const p = rule.style[i]
+                const val = rule.style.getPropertyValue(p).trim()
+                if (val) declarations.set(p, val)
+              }
+            }
+          } catch {
+            continue
+          }
+        }
+      }
+    } catch {
+      continue
+    }
+  }
+  return declarations
+}
+
+describe('buildSheetIndices', () => {
+  it('returns empty pseudo buckets and empty keyframes for an empty sheet array', () => {
+    const indices = buildSheetIndices([])
+    for (const state of PSEUDO_STATES) expect(indices.pseudo[state]).toEqual([])
+    expect(indices.keyframes.size).toBe(0)
+  })
+
+  it('groups rules into hover, focus, and active buckets with selectors normalized', () => {
+    const sheet = cssToSheet(`
+      .btn:hover { color: red; background: blue }
+      .input:focus { outline: 1px solid green }
+      .item:active { transform: scale(0.95) }
+      .static { color: black }
+    `)
+    const indices = buildSheetIndices([sheet])
+
+    expect(indices.pseudo[':hover'].map((e) => e.selector)).toEqual(['.btn'])
+    expect(indices.pseudo[':focus'].map((e) => e.selector)).toEqual(['.input'])
+    expect(indices.pseudo[':active'].map((e) => e.selector)).toEqual(['.item'])
+
+    const hoverDecls = indices.pseudo[':hover'][0].declarations
+    expect(hoverDecls.get('color')).toBe('red')
+    expect(hoverDecls.get('background-color') || hoverDecls.get('background')).toBeTruthy()
+  })
+
+  it('preserves insertion order of selectors across split selector lists', () => {
+    const sheet = cssToSheet(`.a:hover, .b:hover, .c:hover { color: red }`)
+    const indices = buildSheetIndices([sheet])
+    expect(indices.pseudo[':hover'].map((e) => e.selector)).toEqual(['.a', '.b', '.c'])
+  })
+
+  it('shares the same declaration map across pseudo states for mixed selector lists', () => {
+    const sheet = cssToSheet(`.a:hover, .b:focus { color: red }`)
+    const indices = buildSheetIndices([sheet])
+    const hoverEntry = indices.pseudo[':hover'][0]
+    const focusEntry = indices.pseudo[':focus'][0]
+    expect(hoverEntry.declarations).toBe(focusEntry.declarations)
+    expect(hoverEntry.declarations.get('color')).toBe('red')
+  })
+
+  it('collects multiple @keyframes definitions with the same name in insertion order', () => {
+    const sheet = cssToSheet(`
+      @keyframes spin { from { opacity: 0 } to { opacity: 1 } }
+      @keyframes pulse { from { transform: scale(1) } to { transform: scale(1.1) } }
+      @keyframes spin { from { opacity: 0.5 } to { opacity: 1 } }
+    `)
+    const indices = buildSheetIndices([sheet])
+    expect(indices.keyframes.size).toBe(2)
+    const spin = indices.keyframes.get('spin')
+    expect(spin?.length).toBe(2)
+    expect(spin?.[0]).toContain('opacity: 0')
+    expect(spin?.[1]).toContain('opacity: 0.5')
+    expect(indices.keyframes.get('pulse')?.length).toBe(1)
+  })
+
+  it('skips sheets whose cssRules getter throws', () => {
+    const good = cssToSheet(`.btn:hover { color: red }`)
+    const tainted = new Proxy(good, {
+      get(target, prop, _receiver) {
+        if (prop === 'cssRules') throw new Error('SecurityError')
+        return Reflect.get(target, prop, target)
+      },
+    })
+    const indices = buildSheetIndices([tainted, good])
+    expect(indices.pseudo[':hover'].map((e) => e.selector)).toEqual(['.btn'])
+  })
+
+  it('ignores rules that are neither CSSStyleRule nor CSSKeyframesRule', () => {
+    const sheet = cssToSheet(`@media (min-width: 100px) { .x:hover { color: red } }`)
+    const indices = buildSheetIndices([sheet])
+    expect(indices.pseudo[':hover']).toEqual([])
+    expect(indices.keyframes.size).toBe(0)
+  })
+
+  it('returns an empty bucket when a rule selector contains a pseudo only inside a different state', () => {
+    const sheet = cssToSheet(`.a:hover { color: red }`)
+    const indices = buildSheetIndices([sheet])
+    expect(indices.pseudo[':focus']).toEqual([])
+    expect(indices.pseudo[':active']).toEqual([])
+  })
+})
+
+describe('pickPseudoDeclarations', () => {
+  it('returns an empty map when the entries array is empty', () => {
+    document.body.innerHTML = '<div class="a"></div>'
+    const el = document.querySelector('.a')!
+    expect(pickPseudoDeclarations(el, []).size).toBe(0)
+  })
+
+  it('returns an empty map when no entry selector matches the element', () => {
+    document.body.innerHTML = '<div class="a"></div>'
+    const el = document.querySelector('.a')!
+    const decl = new Map<string, string>([['color', 'red']])
+    const entries: PseudoRuleIndexEntry[] = [{ selector: '.never', declarations: decl }]
+    expect(pickPseudoDeclarations(el, entries).size).toBe(0)
+  })
+
+  it('applies last-write-wins across multiple matching entries in iteration order', () => {
+    document.body.innerHTML = '<div class="a b"></div>'
+    const el = document.querySelector('.a')!
+    const entries: PseudoRuleIndexEntry[] = [
+      { selector: '.a', declarations: new Map([['color', 'red']]) },
+      { selector: '.b', declarations: new Map([['color', 'blue'], ['background', 'pink']]) },
+    ]
+    const out = pickPseudoDeclarations(el, entries)
+    expect(out.get('color')).toBe('blue')
+    expect(out.get('background')).toBe('pink')
+  })
+
+  it('skips entries whose selector throws on Element.matches', () => {
+    document.body.innerHTML = '<div class="a"></div>'
+    const el = document.querySelector('.a')!
+    const entries: PseudoRuleIndexEntry[] = [
+      { selector: ':::', declarations: new Map([['color', 'red']]) },
+      { selector: '.a', declarations: new Map([['color', 'green']]) },
+    ]
+    const out = pickPseudoDeclarations(el, entries)
+    expect(out.get('color')).toBe('green')
+  })
+})
+
+describe('extractor pseudo-rule index parity vs legacy implementation', () => {
+  const css = `
+    .card:hover { color: red; background: yellow }
+    .card.primary:hover, .button:focus { color: blue }
+    .button:active { transform: scale(0.95) }
+    .static { color: black }
+    .nested .item:hover { padding: 4px }
+  `
+
+  it('produces declarations identical to the legacy collect for matching elements', () => {
+    document.body.innerHTML = `
+      <div class="card primary"></div>
+      <button class="button"></button>
+      <div class="nested"><span class="item"></span></div>
+    `
+    const sheet = cssToSheet(css)
+    const indices = buildSheetIndices([sheet])
+
+    for (const el of Array.from(document.body.querySelectorAll('*'))) {
+      for (const state of PSEUDO_STATES) {
+        const legacy = legacyCollectPseudoDeclarations(el, state, [sheet])
+        const next = pickPseudoDeclarations(el, indices.pseudo[state])
+        expect(Array.from(next.entries())).toEqual(Array.from(legacy.entries()))
+      }
+    }
+  })
+
+  it('matches the legacy implementation across ten seeded random rule permutations', () => {
+    document.body.innerHTML = `<div class="a"></div><div class="b"></div><div class="c"></div>`
+    const declTokens = ['color: red', 'color: blue', 'padding: 2px', 'margin: 1px', 'opacity: 0.5']
+    const classes = ['a', 'b', 'c']
+    const states = [':hover', ':focus', ':active']
+    let seed = 0xC0FFEE
+    const rng = () => {
+      seed = (seed * 1664525 + 1013904223) >>> 0
+      return seed / 0xFFFFFFFF
+    }
+
+    for (let perm = 0; perm < 10; perm += 1) {
+      const ruleCount = 6 + Math.floor(rng() * 8)
+      const ruleStrings: string[] = []
+      for (let r = 0; r < ruleCount; r += 1) {
+        const cls = classes[Math.floor(rng() * classes.length)]
+        const state = states[Math.floor(rng() * states.length)]
+        const tok = declTokens[Math.floor(rng() * declTokens.length)]
+        ruleStrings.push(`.${cls}${state} { ${tok} }`)
+      }
+      const sheet = cssToSheet(ruleStrings.join('\n'))
+      const indices = buildSheetIndices([sheet])
+      for (const el of Array.from(document.body.querySelectorAll('*'))) {
+        for (const state of PSEUDO_STATES) {
+          const legacy = legacyCollectPseudoDeclarations(el, state, [sheet])
+          const next = pickPseudoDeclarations(el, indices.pseudo[state])
+          expect(Array.from(next.entries())).toEqual(Array.from(legacy.entries()))
+        }
+      }
+    }
+  })
+
+  it('reads cssRules once per sheet during build vs once per call for the legacy collect', () => {
+    document.body.innerHTML = `
+      <div class="a"></div><div class="b"></div><div class="c"></div>
+      <div class="d"></div><div class="e"></div><div class="f"></div>
+      <div class="g"></div><div class="h"></div><div class="i"></div><div class="j"></div>
+    `
+    const sheet = cssToSheet(`.a:hover, .b:hover, .c:hover { color: red } .d:focus { padding: 2px }`)
+    const elements = Array.from(document.body.querySelectorAll('div'))
+
+    const legacyTracker = trackSheet(sheet)
+    for (const el of elements) {
+      for (const state of PSEUDO_STATES) legacyCollectPseudoDeclarations(el, state, [legacyTracker.proxy])
+    }
+
+    const newTracker = trackSheet(sheet)
+    const indices = buildSheetIndices([newTracker.proxy])
+    for (const el of elements) {
+      for (const state of PSEUDO_STATES) pickPseudoDeclarations(el, indices.pseudo[state])
+    }
+
+    expect(legacyTracker.counter.rules).toBe(elements.length * PSEUDO_STATES.length)
+    expect(newTracker.counter.rules).toBe(1)
+    expect(newTracker.counter.rules).toBeLessThan(legacyTracker.counter.rules)
+  })
+})
+
+describe('extractor refactor edge cases', () => {
+  it('treats an empty subtree (zero matching elements) without index access amplification', () => {
+    const tracker = trackSheet(cssToSheet(`.x:hover { color: red }`))
+    buildSheetIndices([tracker.proxy])
+    expect(tracker.counter.rules).toBe(1)
+  })
+
+  it('handles a single-element subtree (N=1) consistently with legacy output', () => {
+    document.body.innerHTML = '<button class="btn"></button>'
+    const sheet = cssToSheet(`.btn:hover { color: red }`)
+    const el = document.querySelector('.btn')!
+    const indices = buildSheetIndices([sheet])
+    const legacy = legacyCollectPseudoDeclarations(el, ':hover', [sheet])
+    const next = pickPseudoDeclarations(el, indices.pseudo[':hover'])
+    expect(Array.from(next.entries())).toEqual(Array.from(legacy.entries()))
+  })
+
+  it('handles a duplicated selector across two rules with last-write-wins semantics', () => {
+    document.body.innerHTML = '<div class="x"></div>'
+    const sheet = cssToSheet(`.x:hover { color: red } .x:hover { color: blue }`)
+    const el = document.querySelector('.x')!
+    const indices = buildSheetIndices([sheet])
+    const out = pickPseudoDeclarations(el, indices.pseudo[':hover'])
+    expect(out.get('color')).toBe('blue')
+  })
+
+  it('handles already-sorted entry order identically to reverse-sorted entry order under last-write-wins', () => {
+    document.body.innerHTML = '<div class="a b"></div>'
+    const el = document.querySelector('.a')!
+    const forward: PseudoRuleIndexEntry[] = [
+      { selector: '.a', declarations: new Map([['color', 'red']]) },
+      { selector: '.b', declarations: new Map([['color', 'blue']]) },
+    ]
+    const reversed = [...forward].reverse()
+    expect(pickPseudoDeclarations(el, forward).get('color')).toBe('blue')
+    expect(pickPseudoDeclarations(el, reversed).get('color')).toBe('red')
+  })
+
+  it('does not mutate the input sheets array when building the index', () => {
+    const sheet = cssToSheet(`.x:hover { color: red }`)
+    const sheets: CSSStyleSheet[] = [sheet]
+    const snapshot = sheets.slice()
+    buildSheetIndices(sheets)
+    expect(sheets).toEqual(snapshot)
+  })
+
+  it('does not mutate the entries array passed to pickPseudoDeclarations', () => {
+    document.body.innerHTML = '<div class="a"></div>'
+    const el = document.querySelector('.a')!
+    const entries: PseudoRuleIndexEntry[] = [
+      { selector: '.a', declarations: new Map([['color', 'red']]) },
+      { selector: '.b', declarations: new Map([['color', 'blue']]) },
+    ]
+    const lengthBefore = entries.length
+    pickPseudoDeclarations(el, entries)
+    expect(entries.length).toBe(lengthBefore)
   })
 })

--- a/src/portableFallback/extractor.ts
+++ b/src/portableFallback/extractor.ts
@@ -170,35 +170,80 @@ const getAllStyleSheetsRecursive = (root: Document | ShadowRoot = document): CSS
 const normalizeSelectorForMatch = (selectorText: string) =>
   selectorText.replace(/:hover/g, '').replace(/:focus-visible/g, '').replace(/:focus-within/g, '').replace(/:focus/g, '').replace(/:active/g, '').trim()
 
-const collectPseudoDeclarations = (el: HTMLElement | SVGElement, pseudo: ':hover' | ':focus' | ':active') => {
+export const PSEUDO_STATES = [':hover', ':focus', ':active'] as const
+export type PseudoState = (typeof PSEUDO_STATES)[number]
+
+export interface PseudoRuleIndexEntry {
+  selector: string
+  declarations: Map<string, string>
+}
+
+export type PseudoRuleIndex = Record<PseudoState, PseudoRuleIndexEntry[]>
+
+export interface SheetIndices {
+  pseudo: PseudoRuleIndex
+  keyframes: Map<string, string[]>
+}
+
+const extractDeclarations = (style: CSSStyleDeclaration): Map<string, string> => {
   const declarations = new Map<string, string>()
-  const allSheets = getAllStyleSheetsRecursive()
-  for (const sheet of allSheets) {
+  for (let i = 0; i < style.length; i += 1) {
+    const prop = style[i]
+    const val = style.getPropertyValue(prop).trim()
+    if (val) declarations.set(prop, val)
+  }
+  return declarations
+}
+
+export const buildSheetIndices = (sheets: readonly CSSStyleSheet[]): SheetIndices => {
+  const pseudo: PseudoRuleIndex = { ':hover': [], ':focus': [], ':active': [] }
+  const keyframes = new Map<string, string[]>()
+
+  for (const sheet of sheets) {
     try {
-      const rules = sheet.cssRules
-      for (const rule of Array.from(rules)) {
-        if (!(rule instanceof CSSStyleRule) || !rule.selectorText.includes(pseudo)) continue
-        for (const sel of rule.selectorText.split(',').map((s) => s.trim())) {
-          if (!sel.includes(pseudo)) continue
-          const norm = normalizeSelectorForMatch(sel)
-          if (norm) {
-            try {
-              if (el.matches(norm)) {
-                for (let i = 0; i < rule.style.length; i++) {
-                  const p = rule.style[i]
-                  const val = rule.style.getPropertyValue(p).trim()
-                  if (val) declarations.set(p, val)
-                }
-              }
-            } catch {
-              continue
-            }
+      for (const rule of Array.from(sheet.cssRules)) {
+        if (rule instanceof CSSKeyframesRule) {
+          const existing = keyframes.get(rule.name)
+          if (existing) existing.push(rule.cssText)
+          else keyframes.set(rule.name, [rule.cssText])
+          continue
+        }
+        if (!(rule instanceof CSSStyleRule)) continue
+        const selectorText = rule.selectorText
+        let extracted: Map<string, string> | undefined
+        for (const state of PSEUDO_STATES) {
+          if (!selectorText.includes(state)) continue
+          for (const sel of selectorText.split(',').map((segment) => segment.trim())) {
+            if (!sel.includes(state)) continue
+            const norm = normalizeSelectorForMatch(sel)
+            if (!norm) continue
+            if (!extracted) extracted = extractDeclarations(rule.style)
+            pseudo[state].push({ selector: norm, declarations: extracted })
           }
         }
       }
     } catch {
       continue
     }
+  }
+
+  return { pseudo, keyframes }
+}
+
+export const pickPseudoDeclarations = (
+  el: Element,
+  entries: readonly PseudoRuleIndexEntry[],
+): Map<string, string> => {
+  const declarations = new Map<string, string>()
+  for (const entry of entries) {
+    let matched = false
+    try {
+      matched = el.matches(entry.selector)
+    } catch {
+      continue
+    }
+    if (!matched) continue
+    for (const [prop, val] of entry.declarations) declarations.set(prop, val)
   }
   return declarations
 }
@@ -464,6 +509,8 @@ export const extractPortableFallbackSubtree = async (
     css += '}\n\n'
   }
 
+  const sheetIndices = buildSheetIndices(getAllStyleSheetsRecursive())
+
   for (let index = 0; index < clonedNodes.length; index++) {
     const node = clonedNodes[index]
     const original = originalNodes[index]
@@ -501,8 +548,8 @@ export const extractPortableFallbackSubtree = async (
     block += '}\n'
     if (hasProps) css += `${block}\n`
 
-    for (const state of [':hover', ':focus', ':active'] as const) {
-      const declarations = collectPseudoDeclarations(original, state)
+    for (const state of PSEUDO_STATES) {
+      const declarations = pickPseudoDeclarations(original, sheetIndices.pseudo[state])
       if (declarations.size) {
         stats.pseudoStateRuleCount += 1
         let stateBlock = `${selector}${state} {\n`
@@ -531,18 +578,11 @@ export const extractPortableFallbackSubtree = async (
     const animationName = computed.animationName
     if (animationName && animationName !== 'none') {
       for (const name of animationName.split(',').map((value) => value.trim())) {
-        const allSheets = getAllStyleSheetsRecursive()
-        for (const sheet of allSheets) {
-          try {
-            for (const rule of Array.from(sheet.cssRules)) {
-              if (rule instanceof CSSKeyframesRule && rule.name === name) {
-                stats.keyframeRuleCount += 1
-                css += `${rule.cssText}\n\n`
-              }
-            }
-          } catch {
-            continue
-          }
+        const cssTexts = sheetIndices.keyframes.get(name)
+        if (!cssTexts) continue
+        for (const text of cssTexts) {
+          stats.keyframeRuleCount += 1
+          css += `${text}\n\n`
         }
       }
     }


### PR DESCRIPTION
Replaces the per-node CSS rule scan inside extractPortableFallbackSubtree
with two pre-built indices (pseudo-state rules and @keyframes by name).
Previously every subtree node triggered three full scans of the page's
stylesheets for :hover/:focus/:active and another scan per animation
name, scaling as O(N · (D + R)). The new path scans the sheets once
during setup and the per-node loop performs O(1) lookups against the
indices, leaving worst-case complexity at O(D + R + N · P) with all
terms independent.

https://claude.ai/code/session_01MfyTY3PGMoNDxcRRexJEq8